### PR TITLE
Update compat bounds of MathOptInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,5 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-MathOptInterface = "~1.8.2"
+MathOptInterface = "1.8"
 julia = "^1.6"


### PR DESCRIPTION
This should let you support any MathOptInterface version `[1.8.x, 2)`. The previous limited to `[1.8.2, 1.9)`, which I don't think is what you intended?

Closes #18 